### PR TITLE
Wrap callback object for enabled in tonumber func

### DIFF
--- a/lua/autorun/client/proximity_voice_init.lua
+++ b/lua/autorun/client/proximity_voice_init.lua
@@ -13,7 +13,7 @@ cvars.AddChangeCallback( "proximity_voice_transmit_only", function( _, _, new )
     if not enabled then return end
     net.Start( "proximity_voice_enabled_changed" )
         net.WriteBool( enabled )
-        net.WriteBool( tobool( new ) )
+        net.WriteBool( tobool( tonumber( new ) ) )
     net.SendToServer()
 end )
 


### PR DESCRIPTION
In its current state, proximity voice does not respond as one would expect with number booleans using incrementvar.

Using this command: `incrementvar proximity_voice_enabled 0 1 1` outputs 0.00, which isn't the same as 0 given the way tobool handles truthy/falsy values.

To fix this, I have wrapped the `new` from the changed callback in a `tonumber()` function.

I'm keeping this a draft until I am able to verify this fix, and that it does not cause any unexpected behaviour.